### PR TITLE
Make the timetable and the departures table somewhat more styleable

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,16 @@ rm rozkladzik.zip
         [[ sensor.rozkladzik_wroclaw_1709.attributes.html_departures ]]
         <big><center>Timetable</center></big>
         [[ sensor.rozkladzik_wroclaw_1709.attributes.html_timetable ]]
+        <style>
+          table.departures, table.timeteble {
+            border: 1px black solid; border-collapse: collapse;
+          }
+          
+          table.departures tr td, table.timeteble tr td{
+            text-align: center; padding: 4px
+          }
+        </style>  
+
     ```
   * HTML Template Card:
     ```yaml
@@ -100,6 +110,51 @@ rm rozkladzik.zip
         {{ state_attr('sensor.rozkladzik_wroclaw_1709','html_departures') }}
         <big><center>Timetable</center></big>
         {{ state_attr('sensor.rozkladzik_wroclaw_1709','html_timetable') }}
+        <style>
+
+          table.departures, table.timeteble {
+            border: 0 transparent;
+          }
+
+          span.kier, span.direction  {
+            display: none;
+          }
+
+          tr.odd-departure, tr.odd-route  {
+            background: rgba(0,0,0,0.2);
+          }
+
+          span.departures  {
+            width: 100%;
+          }
+          
+          span {
+            color: var(--primary-text-color);
+            display: inline-block;
+            font-size: 22px;
+            line-height: 0.5;
+            font-weight: 300;
+            padding: 8px 8px 0px 8px;
+            text-align: right;
+            width:30%;
+          }
+          
+          span.time {
+          }
+          
+          span.route { 
+            width:60px;
+            font-weight:600;
+            color: var(--secondary-text-color);
+          }
+          
+          span.timeteble-route { 
+            width:60px;
+            font-weight:600;
+            color: var(--secondary-text-color);
+          }
+        </style>  
+
     ```
   * This integration is available in [*HACS*](https://github.com/custom-components/hacs/).
 ## FAQ

--- a/custom_components/rozkladzik/sensor.py
+++ b/custom_components/rozkladzik/sensor.py
@@ -79,7 +79,7 @@ class RozkladzikSensor(Entity):
 
     @staticmethod
     def departure_to_str(departure):
-        return '{} kier. {}: {} ({}m)'.format(departure[0], departure[1], departure[2], departure[3])
+        return '<span class="route">{}</span> <span class="kier">kier.</span> <span class="direction">{}:</span> <span class="time">{}</span> <span class="minutes"> {}m </span>'.format(departure[0], departure[1], departure[2], departure[3])
 
     @property
     def unit_of_measurement(self):
@@ -147,27 +147,41 @@ class RozkladzikSensor(Entity):
         self._departures_number = len(self._departures_ordered)
 
     def get_html_timetable(self):
-        html = '<table width="100%" border=1 style="border: 1px black solid; border-collapse: collapse;">\n'
+        html = '<table width="100%" border=1 class="timeteble">\n'
         lines = list(self._departures_by_line.keys())
         lines.sort()
+        departLine = 0;
+        even = "even"
         for line in lines:
             directions = list(self._departures_by_line[line].keys())
             directions.sort()
             for direction in directions:
                 if len(direction) == 0:
                     continue
-                html = html + '<tr><td style="text-align: center; padding: 4px"><big>{}, kier. {}</big></td>'.format(line, direction)
+                if even == "even":
+                    even = "odd"
+                else:
+                    even = "even"
+                departLine = departLine + 1
+                html = html + '<tr class="route-{} {}-route"><td class="timeteble-route"><span class="timeteble-route">{}</span><span class="kier">, kier.</span> <span class="direction">{}</span></td>'.format(departLine, even, line, direction)
                 departures = ', '.join(map(lambda x: x[0], self._departures_by_line[line][direction]))
-                html = html + '<td style="text-align: right; padding: 4px">{}</td></tr>\n'.format(departures)
+                html = html + '<td class="timetable-departures"><span class="departures">{}</span></td></tr>\n'.format(departures)
         if len(lines) == 0:
             html = html + '<tr><td style="text-align: center; padding: 4px">Brak połączeń</td>'
         html = html + '</table>'
         return html
 
     def get_html_departures(self):
-        html = '<table width="100%" border=1 style="border: 1px black solid; border-collapse: collapse;">\n'
+        html = '<table width="100%" border=1 class="departures">\n'
+        departLine = 0;
+        even = "even"
         for departure in self._departures_ordered:
-            html = html + '<tr><td style="text-align: center; padding: 4px">{}</td></tr>\n'.format(
+            departLine = departLine + 1
+            if even == "even":
+                even = "odd"
+            else:
+                even = "even"
+            html = html + '<tr class="departure-{} {}-departure"><td class="departure">{}</td></tr>\n'.format(departLine, even,
                 RozkladzikSensor.departure_to_str(departure))
         html = html + '</table>'
         return html


### PR DESCRIPTION
Love the integration! In order to integrate it with my wall tablet dashboard I needed to style it a little bit more than it was possible before. All I really did was adding some additional spans around the texts.

I've modified the examples to reflect the previous style for the regular html-card and made some creative use of the new styles in the html-template-card. If you like the result, I'd love to contribute to your great work.

![image](https://github.com/PiotrMachowski/Home-Assistant-custom-components-Rozkladzik/assets/1209953/fe98ba53-ec2c-43ce-bbde-276749fbc78f)
